### PR TITLE
Add pricing for gpt-4o models

### DIFF
--- a/src/data/openai.ts
+++ b/src/data/openai.ts
@@ -114,5 +114,23 @@ export const price_openai: PlatformInterface = {
       },
       tags: ['common'],
     },
+    {
+      model: 'gpt-4o',
+      description: 'GPT-4o model with specified rates for input and output tokens.',
+      price: {
+        input: 5,
+        output: 15,
+      },
+      tags: ['common'],
+    },
+    {
+      model: 'gpt-4o-2024-05-13',
+      description: 'GPT-4o model variant with specified rates for input and output tokens.',
+      price: {
+        input: 5,
+        output: 15,
+      },
+      tags: ['common'],
+    },
   ],
 };


### PR DESCRIPTION
Related to #1

This pull request updates the pricing information for OpenAI models in the `src/data/openai.ts` file to include the new gpt-4o and gpt-4o-2024-05-13 models with their specified rates.

- **Adds new models**: Introduces two new models, `gpt-4o` and `gpt-4o-2024-05-13`, with descriptions and pricing details. Both models are priced at $5.00 per 1M tokens for input and $15.00 per 1M tokens for output.
- **Categorization**: Tags both new models as 'common' to align with the existing model categorization within the file.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/1?shareId=9f2e43d8-15cc-4ae6-a434-b56b766b171b).