### PR TITLE
Update GPT-4 Turbo pricing and add variant

### DIFF
--- a/src/data/openai.ts
+++ b/src/data/openai.ts
@@ -17,6 +17,16 @@ export const price_openai: PlatformInterface = {
       tags: ['common'],
     },
     {
+      model: 'gpt-4-turbo-2024-04-09',
+      description:
+        'Variant of GPT-4 Turbo with specific pricing.',
+      price: {
+        input: 10,
+        output: 30,
+      },
+      tags: ['common'],
+    },
+    {
       model: 'GPT-4',
       description:
         'With broad general knowledge and domain expertise, GPT-4 can follow complex instructions in natural language and solve difficult problems with accuracy.',


### PR DESCRIPTION
Related to #3

Adds a new model entry for "gpt-4-turbo-2024-04-09" in the `src/data/openai.ts` file to reflect the updated pricing structure as per the issue request.

- **New Model Addition**: Introduces the "gpt-4-turbo-2024-04-09" model with an input price of $10 and an output price of $30, aligning with the specified pricing structure.
- **Existing Pricing Unchanged**: Ensures that the pricing for "GPT-4 Turbo", "GPT-4", and "GPT-4-32k" remains as is, since they already match the issue's request.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/3?shareId=6d781bed-1a2f-47b8-8222-769245a2c743).