### PR TITLE
Add qwen model series and pricing

### DIFF
--- a/src/data/platform.ts
+++ b/src/data/platform.ts
@@ -4,6 +4,7 @@ import { price_moonshot } from '@/data/moonshot';
 import { price_claude } from '@/data/claude';
 import { price_zhipu } from '@/data/zhipu';
 import { price_baichuan } from '@/data/baichuan';
+import { price_qwen } from '@/data/qwen'; // Importing qwen model series
 
 type ITag = 'common' | 'fine-tuned' | 'custom' | 'embedding' | 'npc';
 export type ModelInterface = {
@@ -35,12 +36,13 @@ export type PlatformInterface = {
   // platform models
   models: ModelInterface[];
 };
-export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan', PlatformInterface> = {
+export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan' | 'qwen', PlatformInterface> = {
   openai: price_openai,
   azure: price_azure,
   claude: price_claude,
   moonshot: price_moonshot,
   zhipu: price_zhipu,
   baichuan: price_baichuan,
+  qwen: price_qwen, // Adding qwen model series to the platforms record
 };
 export const platform_keys = Object.keys(platforms) as Array<keyof typeof platforms>;

--- a/src/data/qwen.ts
+++ b/src/data/qwen.ts
@@ -1,0 +1,82 @@
+import { PlatformInterface } from '@/data/platform';
+
+export const price_qwen: PlatformInterface = {
+  name: 'Qwen',
+  price_unit: 'CNY',
+  price_unit_symbol: '￥',
+  url: 'https://qwen.ai/pricing',
+  models: [
+    {
+      model: 'qwen-long',
+      price: {
+        input: 0.0005 * 1000,
+        output: 0.002 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-turbo',
+      price: {
+        input: 0.002 * 1000,
+        output: 0.006 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-plus',
+      price: {
+        input: 0.004 * 1000,
+        output: 0.012 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max-0428',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max-0403',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max-0107',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max-1201',
+      price: {
+        input: 0.12 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+    {
+      model: 'qwen-max-longcontext',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen-series'],
+    },
+  ],
+};


### PR DESCRIPTION
Related to #7

This pull request introduces the qwen model series, including their pricing details, to the model list in the application.

- **Adds a new data file**: Creates `src/data/qwen.ts` to define the qwen model series, including `qwen-long`, `qwen-turbo`, `qwen-plus`, `qwen-max`, and several variations of `qwen-max` with their respective input and output pricing. All models are tagged under 'qwen-series' for easy identification.
- **Updates the platform list**: Modifies `src/data/platform.ts` to import the newly created `price_qwen` from `src/data/qwen.ts` and adds the qwen model series to the `platforms` record, making it accessible within the application.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/7?shareId=7dfab6b9-15f2-4e7a-ba28-afb5b3991556).