### PR TITLE
Add qwen model series to model list

### DIFF
--- a/src/data/platform.ts
+++ b/src/data/platform.ts
@@ -4,8 +4,9 @@ import { price_moonshot } from '@/data/moonshot';
 import { price_claude } from '@/data/claude';
 import { price_zhipu } from '@/data/zhipu';
 import { price_baichuan } from '@/data/baichuan';
+import { price_qwen } from '@/data/qwen';
 
-type ITag = 'common' | 'fine-tuned' | 'custom' | 'embedding' | 'npc';
+type ITag = 'common' | 'fine-tuned' | 'custom' | 'embedding' | 'npc' | 'qwen';
 export type ModelInterface = {
   // model name
   model: string;
@@ -35,12 +36,13 @@ export type PlatformInterface = {
   // platform models
   models: ModelInterface[];
 };
-export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan', PlatformInterface> = {
+export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan' | 'qwen', PlatformInterface> = {
   openai: price_openai,
   azure: price_azure,
   claude: price_claude,
   moonshot: price_moonshot,
   zhipu: price_zhipu,
   baichuan: price_baichuan,
+  qwen: price_qwen,
 };
 export const platform_keys = Object.keys(platforms) as Array<keyof typeof platforms>;

--- a/src/data/qwen.ts
+++ b/src/data/qwen.ts
@@ -1,0 +1,82 @@
+import { PlatformInterface } from './platform';
+
+export const price_qwen: PlatformInterface = {
+  name: 'qwen',
+  price_unit: 'CNY',
+  price_unit_symbol: '￥',
+  url: 'https://qwen-models.com/pricing',
+  models: [
+    {
+      model: 'qwen-long',
+      price: {
+        input: 0.0005 * 1000,
+        output: 0.002 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-turbo',
+      price: {
+        input: 0.002 * 1000,
+        output: 0.006 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-plus',
+      price: {
+        input: 0.004 * 1000,
+        output: 0.012 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max-0428',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max-0403',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max-0107',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max-1201',
+      price: {
+        input: 0.12 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+    {
+      model: 'qwen-max-longcontext',
+      price: {
+        input: 0.04 * 1000,
+        output: 0.12 * 1000,
+      },
+      tags: ['qwen'],
+    },
+  ],
+};


### PR DESCRIPTION
Related to #7

This pull request introduces the qwen model series, including their pricing details, into the model list.

- **Adds a new file `src/data/qwen.ts`** to define the qwen model series and their pricing, exporting a `PlatformInterface` object named `price_qwen` which includes model names, pricing for input and output tokens, and tags for each model.
- **Updates `src/data/platform.ts`** to import the `price_qwen` object and add it to the `platforms` record, thereby integrating the qwen model series into the application. Additionally, a new tag 'qwen' is added to the `ITag` type to facilitate filtering and categorization.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/7?shareId=36a0766a-abf3-4561-8213-763fb4afbe25).