### PR TITLE
Add deepseek platform and models

### DIFF
--- a/src/data/deepseek.ts
+++ b/src/data/deepseek.ts
@@ -1,0 +1,28 @@
+import { PlatformInterface } from './platform';
+
+export const price_deepseek: PlatformInterface = {
+  name: 'deepseek',
+  price_unit: 'CNY',
+  price_unit_symbol: '¥',
+  url: 'https://deepseek.example.com/pricing',
+  models: [
+    {
+      model: 'deepseek-chat',
+      description: 'Good at general tasks, 32K context length',
+      price: {
+        input: 1,
+        output: 2,
+      },
+      tags: ['common'],
+    },
+    {
+      model: 'deepseek-coder',
+      description: 'Good at coding tasks, 16K context length',
+      price: {
+        input: 1,
+        output: 2,
+      },
+      tags: ['common'],
+    },
+  ],
+};

--- a/src/data/platform.ts
+++ b/src/data/platform.ts
@@ -5,6 +5,7 @@ import { price_claude } from '@/data/claude';
 import { price_zhipu } from '@/data/zhipu';
 import { price_baichuan } from '@/data/baichuan';
 import { price_qwen } from '@/data/qwen';
+import { price_deepseek } from '@/data/deepseek';
 
 type ITag = 'common' | 'fine-tuned' | 'custom' | 'embedding' | 'npc' | 'qwen';
 export type ModelInterface = {
@@ -36,7 +37,7 @@ export type PlatformInterface = {
   // platform models
   models: ModelInterface[];
 };
-export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan' | 'qwen', PlatformInterface> = {
+export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan' | 'qwen' | 'deepseek', PlatformInterface> = {
   openai: price_openai,
   azure: price_azure,
   claude: price_claude,
@@ -44,5 +45,6 @@ export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhi
   zhipu: price_zhipu,
   baichuan: price_baichuan,
   qwen: price_qwen,
+  deepseek: price_deepseek,
 };
 export const platform_keys = Object.keys(platforms) as Array<keyof typeof platforms>;


### PR DESCRIPTION
Related to #10

Adds the deepseek platform, including its models and pricing, to the `llm-price` repository.
- **New File Creation**: Introduces `src/data/deepseek.ts` defining the `price_deepseek` object with the deepseek platform's name, price unit, price unit symbol, URL, and models (`deepseek-chat` and `deepseek-coder`) along with their descriptions, pricing, and tags.
- **Code Update**: Modifies `src/data/platform.ts` to import the `price_deepseek` object and adds the `deepseek` platform to the `platforms` object, ensuring the new platform and its models are integrated into the existing structure.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/10?shareId=bc7e7132-1596-49d0-99b6-416aa0e554d8).