### PR TITLE
Add compare functionality to model cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
   const [outputTokenSize, setOutputTokenSize] = useState<number>(1000);
   const [outputPriceUnit, setOutputPriceUnit] = useState<'USD' | 'CNY'>('USD');
   const [outputPriceUnitSymbol, setOutputPriceUnitSymbol] = useState<'$' | '¥'>('$');
+  const [compareList, setCompareList] = useState([]);
 
   const quickSizes = [1000, 5000, 10000, 100000, 1000000];
 
@@ -48,6 +49,26 @@ export default function Home() {
       setOutputPriceUnit(outputPriceUnit);
     }
   }, []);
+
+  useEffect(() => {
+    const storedCompareList = JSON.parse(localStorage.getItem('compareList') || '[]');
+    setCompareList(storedCompareList);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('compareList', JSON.stringify(compareList));
+  }, [compareList]);
+
+  const addToCompare = (model) => {
+    if (!compareList.find((m) => m.model === model.model)) {
+      setCompareList([...compareList, model]);
+    }
+  };
+
+  const removeFromCompare = (model) => {
+    setCompareList(compareList.filter((m) => m.model !== model.model));
+  };
+
   return (
     <main className="pb-24 flex min-h-screen flex-col items-center px-2 md:px-24 light text-foreground bg-background">
       <div
@@ -198,6 +219,9 @@ export default function Home() {
                               inputPrice={inputPrice}
                               outputPrice={outputPrice}
                               total={total}
+                              onAddToCompare={() => addToCompare(model)}
+                              onRemoveFromCompare={() => removeFromCompare(model)}
+                              isInCompareList={compareList.some((m) => m.model === model.model)}
                             />
                           );
                         })}
@@ -209,6 +233,39 @@ export default function Home() {
             );
           })}
         </Tabs>
+      </div>
+      <div className="mt-5 w-full max-w-5xl">
+        <h2 className="text-xl font-semibold">Compare List</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {compareList.map((model, index) => (
+            <ModelCard
+              key={model.model}
+              model={model.model}
+              description={model.description || ''}
+              inputPrice={getFormatedPrice(
+                (model.price.input * inputTokenSize) / 1000000,
+                model.price_unit,
+                outputPriceUnit,
+              )}
+              outputPrice={model.price.output
+                ? getFormatedPrice(
+                  (model.price.output * outputTokenSize) / 1000000,
+                  model.price_unit,
+                  outputPriceUnit,
+                )
+                : undefined}
+              total={getFormatedPrice(
+                (model.price.input * inputTokenSize) / 1000000 +
+                ((model.price.output || 0) * outputTokenSize) / 1000000,
+                model.price_unit,
+                outputPriceUnit,
+              )}
+              onAddToCompare={() => {}}
+              onRemoveFromCompare={() => removeFromCompare(model)}
+              isInCompareList={true}
+            />
+          ))}
+        </div>
       </div>
     </main>
   );

--- a/src/components/ModelCard.tsx
+++ b/src/components/ModelCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardBody, Code, Divider, Button } from '@nextui-org/react';
+import { Card, CardBody, Code, Divider, Button, Tooltip } from '@nextui-org/react';
 
 interface ModelCardProps {
   model: string;
@@ -13,24 +13,50 @@ interface ModelCardProps {
 }
 
 export const ModelCard: React.FC<ModelCardProps> = ({
-  model,
-  description,
-  inputPrice,
-  outputPrice,
-  total,
-  onAddToCompare,
-  onRemoveFromCompare,
-  isInCompareList,
-}) => {
+                                                      model,
+                                                      description,
+                                                      inputPrice,
+                                                      outputPrice,
+                                                      total,
+                                                      onAddToCompare,
+                                                      onRemoveFromCompare,
+                                                      isInCompareList,
+                                                    }) => {
   return (
     <Card>
       <CardBody>
         <div className={'flex flex-col gap-2 justify-between h-full'}>
           <div className={'flex justify-between'}>
             {model}
-            <Code size={'sm'} className={'text-xs'} radius={'sm'}>
-              Total: {total}
-            </Code>
+            <div className={'flex justify-end gap-1'}>
+              <Code size={'sm'} className={'text-xs'} radius={'sm'}>
+                Total: {total}
+              </Code>
+              {!isInCompareList && (
+                <Tooltip content={'Add to compare'} color={'secondary'} showArrow={true}>
+                  <a
+                    className={'cursor-pointer flex justify-center w-7 bg-amber-50px-2 py-1 h-fit font-mono font-normal whitespace-nowrap bg-default/40 text-default-foreground rounded-small text-xs'}
+                    onClick={onAddToCompare}>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
+                      <path
+                        d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
+                    </svg>
+                  </a>
+                </Tooltip>
+              )}
+              {isInCompareList && (
+                <Tooltip content={'Remove from compare'} color={'secondary'} showArrow={true}>
+                  <a
+                    className={'cursor-pointer flex justify-center w-7 bg-amber-50px-2 py-1 h-fit font-mono font-normal whitespace-nowrap bg-default/40 text-default-foreground rounded-small text-xs'}
+                    onClick={onRemoveFromCompare}>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
+                      <path d="M3.75 7.25a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z" />
+                    </svg>
+
+                  </a>
+                </Tooltip>
+              )}
+            </div>
           </div>
           <div className={'text-[12px] text-gray-500'}>{description}</div>
 
@@ -47,18 +73,7 @@ export const ModelCard: React.FC<ModelCardProps> = ({
               )}
             </div>
           </div>
-          <div className="flex justify-end gap-2">
-            {!isInCompareList && (
-              <Button auto flat color="success" onClick={onAddToCompare}>
-                Add to Compare
-              </Button>
-            )}
-            {isInCompareList && (
-              <Button auto flat color="error" onClick={onRemoveFromCompare}>
-                Remove from Compare
-              </Button>
-            )}
-          </div>
+
         </div>
       </CardBody>
     </Card>

--- a/src/components/ModelCard.tsx
+++ b/src/components/ModelCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardBody, Code, Divider } from '@nextui-org/react';
+import { Card, CardBody, Code, Divider, Button } from '@nextui-org/react';
 
 interface ModelCardProps {
   model: string;
@@ -7,9 +7,21 @@ interface ModelCardProps {
   inputPrice: string;
   outputPrice?: string;
   total: string;
+  onAddToCompare: () => void;
+  onRemoveFromCompare: () => void;
+  isInCompareList: boolean;
 }
 
-export const ModelCard: React.FC<ModelCardProps> = ({ model, description, inputPrice, outputPrice, total }) => {
+export const ModelCard: React.FC<ModelCardProps> = ({
+  model,
+  description,
+  inputPrice,
+  outputPrice,
+  total,
+  onAddToCompare,
+  onRemoveFromCompare,
+  isInCompareList,
+}) => {
   return (
     <Card>
       <CardBody>
@@ -34,6 +46,18 @@ export const ModelCard: React.FC<ModelCardProps> = ({ model, description, inputP
                 </div>
               )}
             </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            {!isInCompareList && (
+              <Button auto flat color="success" onClick={onAddToCompare}>
+                Add to Compare
+              </Button>
+            )}
+            {isInCompareList && (
+              <Button auto flat color="error" onClick={onRemoveFromCompare}>
+                Remove from Compare
+              </Button>
+            )}
           </div>
         </div>
       </CardBody>

--- a/src/data/platform.ts
+++ b/src/data/platform.ts
@@ -8,6 +8,7 @@ import { price_qwen } from '@/data/qwen';
 import { price_deepseek } from '@/data/deepseek';
 
 type ITag = 'common' | 'fine-tuned' | 'custom' | 'embedding' | 'npc' | 'qwen';
+export type IPlatform = 'openai' | 'azure' | 'claude' | 'moonshot' | 'zhipu' | 'baichuan' | 'qwen' | 'deepseek';
 export type ModelInterface = {
   // model name
   model: string;
@@ -37,7 +38,7 @@ export type PlatformInterface = {
   // platform models
   models: ModelInterface[];
 };
-export const platforms: Record<'openai' | 'azure' | 'moonshot' | 'claude' | 'zhipu' | 'baichuan' | 'qwen' | 'deepseek', PlatformInterface> = {
+export const platforms: Record<IPlatform, PlatformInterface> = {
   openai: price_openai,
   azure: price_azure,
   claude: price_claude,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Utility functions for managing the compare list in localStorage
+export const compareListUtils = {
+  addModelToCompare: (model) => {
+    const compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
+    if (!compareList.find((m) => m.model === model.model)) {
+      compareList.push(model);
+      localStorage.setItem('compareList', JSON.stringify(compareList));
+    }
+  },
+  removeModelFromCompare: (model) => {
+    let compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
+    compareList = compareList.filter((m) => m.model !== model.model);
+    localStorage.setItem('compareList', JSON.stringify(compareList));
+  },
+  isModelInCompare: (model) => {
+    const compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
+    return !!compareList.find((m) => m.model === model.model);
+  },
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,22 +5,3 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-// Utility functions for managing the compare list in localStorage
-export const compareListUtils = {
-  addModelToCompare: (model) => {
-    const compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
-    if (!compareList.find((m) => m.model === model.model)) {
-      compareList.push(model);
-      localStorage.setItem('compareList', JSON.stringify(compareList));
-    }
-  },
-  removeModelFromCompare: (model) => {
-    let compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
-    compareList = compareList.filter((m) => m.model !== model.model);
-    localStorage.setItem('compareList', JSON.stringify(compareList));
-  },
-  isModelInCompare: (model) => {
-    const compareList = JSON.parse(localStorage.getItem('compareList') || '[]');
-    return !!compareList.find((m) => m.model === model.model);
-  },
-};


### PR DESCRIPTION
Related to #12

This pull request introduces the ability to add and remove models from a comparison list directly from the model cards, along with displaying the comparison list on the page and persisting it across sessions using localStorage.

- **ModelCard Component Enhancements**: Adds "Add to Compare" and "Remove from Compare" buttons to each model card. Implements conditional rendering to toggle between these buttons based on whether the model is currently in the compare list.
- **Page State Management**: Updates the main page component to include state management for the compare list, adding and removing models from the list, and rendering a new section to display models currently in the compare list. It also ensures that the compare list is stored in and retrieved from localStorage, allowing the list to persist across page refreshes.
- **Price Calculation Update**: Ensures that the models' token prices are calculated as part of the overall logic, including those models added to the compare list.
- **Utility Functions**: Adds utility functions in `src/lib/utils.ts` for managing the compare list in localStorage, including adding, removing, and checking for the presence of models in the list.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/12?shareId=67018ec8-531d-43f3-971e-3ef27327045e).