### PR TITLE
Add GPT-4o models with pricing information

### DIFF
--- a/src/data/openai.ts
+++ b/src/data/openai.ts
@@ -114,5 +114,35 @@ export const price_openai: PlatformInterface = {
       },
       tags: ['common'],
     },
+    {
+      model: 'gpt-4o',
+      description: 'GPT-4o model with specified rates for input and output tokens.',
+      price: {
+        input: 5,
+        output: 15,
+      },
+      tags: ['common'],
+    },
+    {
+      model: 'gpt-4o-2024-05-13',
+      description: 'GPT-4o model variant with specified rates for input and output tokens.',
+      price: {
+        input: 5,
+        output: 15,
+      },
+      tags: ['common'],
+    },
   ],
 };
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Related to #1

Add pricing information for gpt-4o and gpt-4o-2024-05-13 models to `src/data/openai.ts`.

* Add new model `gpt-4o` with input price 5 and output price 15, tagged as 'common'.
* Add new model `gpt-4o-2024-05-13` with input price 5 and output price 15, tagged as 'common'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/small-tou/llm-price/issues/1?shareId=9177443e-c28c-4271-96c4-d2966d62dfd7).